### PR TITLE
Mdmooney: Alarm wrapping, SetAlarm cleanup

### DIFF
--- a/Team4Clock/Alarm.cs
+++ b/Team4Clock/Alarm.cs
@@ -6,11 +6,19 @@ using System.Threading.Tasks;
 
 namespace Team4Clock
 {
-    class Alarm
+    public class Alarm
     {
         private bool on;
-        private DateTime time;
-        private Object ringtone;
+        public DateTime time
+        {
+            get;
+            private set;
+        }
+        public Object ringtone
+        {
+            get;
+            set;
+        }
         private AlarmRepeats repeatDays = new AlarmRepeats();  // Wrapper for repeat days
 
         //This is the contructor for the Alarm Class
@@ -19,6 +27,15 @@ namespace Team4Clock
             this.time = time;
             this.on = true;
         }
+        
+        // Alternate constructor which takes a TimeSpan reference,
+        // and calls SetAlarmTime().
+        public Alarm(TimeSpan timeSpan)
+        {
+            SetAlarmTime(timeSpan);
+            this.on = true;
+        }
+
         //This return whether the alarm is set on or off
         public bool toggleAlarmOn()
         {
@@ -44,7 +61,8 @@ namespace Team4Clock
             // should call delete from the alarm list
         }
 
-        //This gets the time the alarm is set to
+        // This gets the time the alarm is set to
+        // *DEPRECATED* Prefer the use of C# style getter.
         public DateTime getTime()
         {
             return time;
@@ -62,12 +80,14 @@ namespace Team4Clock
         }
 
         //This gets the ringtone the is set to this alarm
+        // *DEPRECATED* Prefer the use of C# style getter.
         public Object getRingtone()
         {
             return ringtone;
         }
 
         //This is to set the ringtone for the alarm
+        // *DEPRECATED* Prefer the use of C# style setter.
         public void setRingtone(Object obj)
         {
             this.ringtone = obj;
@@ -89,9 +109,12 @@ namespace Team4Clock
             DateTime alarmTime = DateTime.Now.Date;
             if (currTime >= newTime)
             {
-                alarmTime.AddDays(1);
+                Console.WriteLine("Time has already passed, incrementing day...");
+                alarmTime = alarmTime.AddDays(1);
             }
-            alarmTime.Add(newTime);
+            Console.WriteLine("NewTime: " +newTime);
+            alarmTime += newTime;
+            Console.WriteLine("AlarmTime: " + alarmTime);
             this.time = alarmTime;
         }
 

--- a/Team4Clock/Alarm.cs
+++ b/Team4Clock/Alarm.cs
@@ -109,12 +109,9 @@ namespace Team4Clock
             DateTime alarmTime = DateTime.Now.Date;
             if (currTime >= newTime)
             {
-                Console.WriteLine("Time has already passed, incrementing day...");
                 alarmTime = alarmTime.AddDays(1);
             }
-            Console.WriteLine("NewTime: " +newTime);
             alarmTime += newTime;
-            Console.WriteLine("AlarmTime: " + alarmTime);
             this.time = alarmTime;
         }
 
@@ -129,7 +126,7 @@ namespace Team4Clock
         {
             DateTime newTime = date.Date;        // new date, with time reset to midnight
             TimeSpan alarmTime = time.TimeOfDay;
-            newTime.Add(alarmTime);
+            newTime += alarmTime;
             this.time = newTime;
         }
 

--- a/Team4Clock/AlarmUI.xaml.cs
+++ b/Team4Clock/AlarmUI.xaml.cs
@@ -23,10 +23,11 @@ namespace Team4Clock
 
         private Alarm a;
 
-        public AlarmUI(DateTime inputAlarm)
+        public AlarmUI(Alarm inputAlarm)
         {
             InitializeComponent();
-            this.a = new Alarm(inputAlarm);
+            //this.a = new Alarm(inputAlarm);
+            this.a = inputAlarm;
             alarmTime.Content = a.displayTime();
         }
 

--- a/Team4Clock/ListOfAlarms.xaml.cs
+++ b/Team4Clock/ListOfAlarms.xaml.cs
@@ -21,7 +21,7 @@ namespace Team4Clock
     public partial class ListOfAlarms : UserControl
     {
         private MainWindow mw = new MainWindow();
-        private List<DateTime> alarmList;
+        private List<Alarm> alarmList;
        
         public ListOfAlarms()
         {
@@ -30,7 +30,7 @@ namespace Team4Clock
 
         }
 
-        public ListOfAlarms(MainWindow mw, List<DateTime> list)
+        public ListOfAlarms(MainWindow mw, List<Alarm> list)
         {
             
             this.mw = mw;
@@ -49,7 +49,7 @@ namespace Team4Clock
 
         private void addAlarms()
         {
-            foreach(DateTime i in alarmList)
+            foreach(Alarm i in alarmList)
             {
                 AlarmUI alarm = new AlarmUI(i);  
                this.listStack.Children.Add(alarm);

--- a/Team4Clock/MainWindow.xaml.cs
+++ b/Team4Clock/MainWindow.xaml.cs
@@ -24,7 +24,7 @@ namespace Team4Clock
     {
         private SWClock clock;
    
-        private List<DateTime> list = new List<DateTime>();
+        private List<Alarm> list = new List<Alarm>();
         private int snoozeDelay;
         private int setDelay = 3;
 
@@ -76,9 +76,9 @@ namespace Team4Clock
         {
             this.TImeLabel.Content = clock.ShowTime;
             snoozeTick();
-            foreach (DateTime alarm in list)
+            foreach (Alarm alarm in list)
             {
-                if(DateTime.Compare(clock.getCurrentTime(), alarm) == 0)
+                if(DateTime.Compare(clock.getCurrentTime(), alarm.time) == 0)
                 {
                     Console.Beep();
                 }
@@ -125,7 +125,7 @@ namespace Team4Clock
             Main.Children.Add(setAlarm);
         }
 
-        public void setList(DateTime alarm)
+        public void setList(Alarm alarm)
         {
             list.Add(alarm);
             Console.WriteLine(alarm);

--- a/Team4Clock/SetAlarm.xaml
+++ b/Team4Clock/SetAlarm.xaml
@@ -17,16 +17,20 @@
             <Label x:Name="min2Lbl" Content="0" FontSize="26.667" HorizontalContentAlignment="Center" VerticalContentAlignment="Center" Margin="233,92,185,118"/>
             <Button x:Name="min2BtnDown" Content="-" Click="min2BtnDown_Click" Margin="233,187,185,86"/>
             <Button x:Name="backBtn" Content="Back" Margin="35,253,383,15"  Width="75" Click="backBtn_Click" Height="37"/>
-            <Button x:Name="pmBtn" Content="PM" Width="75" Height="37" Canvas.Top="22" Click="pmBtn_Click" Margin="380,112,38,156"/>
-            <Button x:Name="amBtn" Content="AM" Width="75" Canvas.Top="59" Height="37" Click="amBtn_Click" Margin="380,149,38,119"/>
+            <Grid Name="AmPmButtons">
+                <RadioButton x:Name="amBtn" Content="AM" Width="75" Height="37" Canvas.Top="22" Click="amBtn_Click" Margin="380,112,38,156" IsChecked="True"/>
+                <RadioButton x:Name="pmBtn" Content="PM" Width="75" Canvas.Top="59" Height="37" Click="pmBtn_Click" Margin="380,149,38,119"/>
+            </Grid>
             <Button x:Name="doneBtn" Content="Done" Margin="380,253,38,15"  Width="75" Height="37" Click="doneBtn_Click"/>
-            <Button x:Name="sunBtn" Content="Su"  Margin="35,10,398,275"  Width="60" Click="sunBtn_Click"/>
-            <Button x:Name="monBtn" Content="Mo" Margin="95,10,338,275"  Width="60" Click="monBtn_Click"/>
-            <Button x:Name="tueBtn" Content="Tu"  Margin="155,10,278,275"  Width="60" Click="tueBtn_Click"/>
-            <Button x:Name="wedBtn" Content="We"  Margin="215,10,218,275" Width="60" RenderTransformOrigin="0.001,0.571" Click="wedBtn_Click"/>
-            <Button x:Name="thuBtn" Content="Th" Margin="275,10,158,275" Width="60" Click="thuBtn_Click" RenderTransformOrigin="0.983,-5.642"/>
-            <Button x:Name="friBtn" Content="Fr" Margin="335,10,98,275" Width="60" RenderTransformOrigin="-0.284,0.91" Click="friBtn_Click"/>
-            <Button x:Name="satBtn" Content="Sa" Margin="395,10,38,275" Width="60" Click="satBtn_Click"/>
+            <Grid Name="DayButtons"> <!-- using this as a container for day-of-week buttons -->
+                <RadioButton x:Name="sunBtn" Style="{StaticResource {x:Type ToggleButton}}" Content="Su"  Margin="35,10,398,275"  Width="60" Click="btn_Click"/>
+                <RadioButton x:Name="monBtn" Style="{StaticResource {x:Type ToggleButton}}" Content="Mo" Margin="95,10,338,275"  Width="60" Click="btn_Click"/>
+                <RadioButton x:Name="tueBtn" Style="{StaticResource {x:Type ToggleButton}}" Content="Tu"  Margin="155,10,278,275"  Width="60" Click="btn_Click"/>
+                <RadioButton x:Name="wedBtn" Style="{StaticResource {x:Type ToggleButton}}" Content="We"  Margin="215,10,218,275" Width="60" RenderTransformOrigin="0.001,0.571" Click="btn_Click"/>
+                <RadioButton x:Name="thuBtn" Style="{StaticResource {x:Type ToggleButton}}" Content="Th" Margin="275,10,158,275" Width="60" Click="btn_Click" RenderTransformOrigin="0.983,-5.642"/>
+                <RadioButton x:Name="friBtn" Style="{StaticResource {x:Type ToggleButton}}" Content="Fr" Margin="335,10,98,275" Width="60" RenderTransformOrigin="-0.284,0.91" Click="btn_Click"/>
+                <RadioButton x:Name="satBtn" Style="{StaticResource {x:Type ToggleButton}}" Content="Sa" Margin="395,10,38,275" Width="60" Click="btn_Click"/>
+            </Grid>
             <Label x:Name="errLbl" Content="" VerticalContentAlignment="Center" HorizontalContentAlignment="Center" Margin="113,262,118,15" Width="262" Background="White" Foreground="Red"/>
             <Label Content="Repeat?" HorizontalAlignment="Left" Margin="0,29,0,0" VerticalAlignment="Top"/>
             <CheckBox x:Name="rptBoxSun" Content="" HorizontalAlignment="Left" Margin="68,35,0,0" VerticalAlignment="Top"/>

--- a/Team4Clock/SetAlarm.xaml.cs
+++ b/Team4Clock/SetAlarm.xaml.cs
@@ -19,7 +19,7 @@ namespace Team4Clock
     {
         private bool pmClicked = false;  // checks if the pm button has been pressed
         private bool amClicked = false;  // checks if the am button has been pressed
-        private int day = 0;            // SUN = 0 MON = 1 TUE = 2 WED = 3 THU = 4 FRI = 5 SAT = 6
+        private DayOfWeek day = DayOfWeek.Sunday;
         private int amOrPm = 0;         // pm = 1 and am = 2
         private MainWindow mw = new MainWindow(); // The parent view object
 
@@ -27,6 +27,8 @@ namespace Team4Clock
         {
             this.mw = newMW; // The parent view is set 
             InitializeComponent();
+            // initialize the Sunday button to "pressed" state (null-day state is not possible)
+            sunBtn.Background = new SolidColorBrush((Color)ColorConverter.ConvertFromString("#FF707070"));
         }
 
         // Removes the current set alarm view from the stack allowing
@@ -159,43 +161,32 @@ namespace Team4Clock
             {
                 errLbl.Content = "Please select AM or PM";
             }
-            else if(day == 0)
-            {
-                errLbl.Content = "Please select a day (MON - SUN)";
-            }
             else
             {
                 String min = Convert.ToString(min1Lbl.Content) + Convert.ToString(min2Lbl.Content);
-                /*
-                    DateTime(year,month,day,hour,min,sec)
-                    *day is being used for now from SUN - SAT (0 - 6)
-                    *hour is being used as hour (1 - 12)
-                    *min is being used as min (0 - 59)
-                    *seconds is being used for now for AM and PM
-                */
-                //DateTime test = new DateTime(2017, 2, day, Convert.ToInt32(hrLbl.Content), Convert.ToInt32(min), amOrPm);
                 (this.Parent as Panel).Children.Remove(this);
 
                 int hours = Convert.ToInt32(hrLbl.Content);
                 hours = (amOrPm == 1) ? (hours + 12) : hours;
                 hours = (hours == 24) ? 0 : hours;
-                DateTime dt = DateTime.Now;
-                DateTime alarm = new DateTime(dt.Year,dt.Month,dt.Day,hours,Convert.ToInt32(min),0);
-                mw.setList(alarm);
+                TimeSpan alarmTime = new TimeSpan(hours, Convert.ToInt32(min), 0);
+                Alarm alarm = new Alarm(alarmTime);
 
                 // Get repeat days and update the alarm with these days
-                // This is temporarily disabled -- do we even instantiate Alarms anymore?
-                /*List<DayOfWeek> rptDays = GetCheckboxDays();
+                // Todo: update for variable repeats (i.e. different times for different days)
+                List<DayOfWeek> rptDays = GetCheckboxDays();
                 foreach (DayOfWeek rptDay in rptDays)
                 {
-                    myAlarm.SetRepeat(rptDay, true);
-                }*/
+                    alarm.SetRepeat(rptDay, true);
+                }
+
+                mw.setList(alarm);
             }
         }
 
         private void sunBtn_Click(object sender, RoutedEventArgs e)
         {
-            day = 0;
+            day = DayOfWeek.Sunday;
             sunBtn.Background = new SolidColorBrush((Color)ColorConverter.ConvertFromString("#FF707070"));
             monBtn.Background = new SolidColorBrush((Color)ColorConverter.ConvertFromString("#FFDDDDDD"));
             tueBtn.Background = new SolidColorBrush((Color)ColorConverter.ConvertFromString("#FFDDDDDD"));
@@ -207,7 +198,7 @@ namespace Team4Clock
 
         private void monBtn_Click(object sender, RoutedEventArgs e)
         {
-            day = 1;
+            day = DayOfWeek.Monday;
             sunBtn.Background = new SolidColorBrush((Color)ColorConverter.ConvertFromString("#FFDDDDDD"));
             monBtn.Background = new SolidColorBrush((Color)ColorConverter.ConvertFromString("#FF707070"));
             tueBtn.Background = new SolidColorBrush((Color)ColorConverter.ConvertFromString("#FFDDDDDD"));
@@ -219,7 +210,7 @@ namespace Team4Clock
 
         private void tueBtn_Click(object sender, RoutedEventArgs e)
         {
-            day = 2;
+            day = DayOfWeek.Tuesday;
             sunBtn.Background = new SolidColorBrush((Color)ColorConverter.ConvertFromString("#FFDDDDDD"));
             monBtn.Background = new SolidColorBrush((Color)ColorConverter.ConvertFromString("#FFDDDDDD"));
             tueBtn.Background = new SolidColorBrush((Color)ColorConverter.ConvertFromString("#FF707070"));
@@ -231,7 +222,7 @@ namespace Team4Clock
 
         private void wedBtn_Click(object sender, RoutedEventArgs e)
         {
-            day = 3;
+            day = DayOfWeek.Wednesday;
             sunBtn.Background = new SolidColorBrush((Color)ColorConverter.ConvertFromString("#FFDDDDDD"));
             monBtn.Background = new SolidColorBrush((Color)ColorConverter.ConvertFromString("#FFDDDDDD"));
             tueBtn.Background = new SolidColorBrush((Color)ColorConverter.ConvertFromString("#FFDDDDDD"));
@@ -243,7 +234,7 @@ namespace Team4Clock
 
         private void thuBtn_Click(object sender, RoutedEventArgs e)
         {
-            day = 4;
+            day = DayOfWeek.Thursday;
             sunBtn.Background = new SolidColorBrush((Color)ColorConverter.ConvertFromString("#FFDDDDDD"));
             monBtn.Background = new SolidColorBrush((Color)ColorConverter.ConvertFromString("#FFDDDDDD"));
             tueBtn.Background = new SolidColorBrush((Color)ColorConverter.ConvertFromString("#FFDDDDDD"));
@@ -255,7 +246,7 @@ namespace Team4Clock
 
         private void friBtn_Click(object sender, RoutedEventArgs e)
         {
-            day = 5;
+            day = DayOfWeek.Friday;
             sunBtn.Background = new SolidColorBrush((Color)ColorConverter.ConvertFromString("#FFDDDDDD"));
             monBtn.Background = new SolidColorBrush((Color)ColorConverter.ConvertFromString("#FFDDDDDD"));
             tueBtn.Background = new SolidColorBrush((Color)ColorConverter.ConvertFromString("#FFDDDDDD"));
@@ -267,7 +258,7 @@ namespace Team4Clock
 
         private void satBtn_Click(object sender, RoutedEventArgs e)
         {
-            day = 6;
+            day = DayOfWeek.Saturday;
             sunBtn.Background = new SolidColorBrush((Color)ColorConverter.ConvertFromString("#FFDDDDDD"));
             monBtn.Background = new SolidColorBrush((Color)ColorConverter.ConvertFromString("#FFDDDDDD"));
             tueBtn.Background = new SolidColorBrush((Color)ColorConverter.ConvertFromString("#FFDDDDDD"));


### PR DESCRIPTION
Wrapped all `DateTime `references into `Alarm` objects. This also required some cleanup work on the `SetAlarm` class and XAML, both of which have been simplified. Other than some alterations to the interface of `SetAlarm`, there should be no behavioural changes in this patch. This includes some negative behaviour (like that we currently ignore the day the alarm is set to and just defualt to today).